### PR TITLE
SecurityPolicyResourceHelper: Updated SID matching regular expression (Fixed #35)

### DIFF
--- a/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
+++ b/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
@@ -27,9 +27,10 @@ $headerSettings = @{
     TicketValidateClient = "Kerberos Policy"
 }
 
-function Get-IniContent 
+function Get-IniContent
 {
-  [CmdletBinding()]
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
     param
     (
         [Parameter(Mandatory=$true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName=$true)]

--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -164,7 +164,7 @@ function ConvertTo-LocalFriendlyName
     foreach ($id in $SID)
     {        
         Write-Verbose "Received Identity ($id)"
-        if ($null -ne $id -and $id -match 'S-')
+        if ($null -ne $id -and $id -match '^(S-[0-9-]{3,})')
         {
             try
             {

--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -162,14 +162,16 @@ function ConvertTo-LocalFriendlyName
     $friendlyNames = [String[]]@()
 
     foreach ($id in $SID)
-    {        
+    {
+        $id = $id.Trim();
+        
         Write-Verbose "Received Identity ($id)"
         if ($null -ne $id -and $id -match '^(S-[0-9-]{3,})')
         {
             try
             {
                 Write-Verbose "Translating Identity: $id"
-                $securityIdentifier = [System.Security.Principal.SecurityIdentifier]($id.trim())
+                $securityIdentifier = [System.Security.Principal.SecurityIdentifier]($id)
                 $user = $securityIdentifier.Translate([System.Security.Principal.NTAccount])
                 $friendlyNames += $user.value
                 Write-Verbose "Identity ($id) is equal to $($user.Value)"
@@ -181,11 +183,11 @@ function ConvertTo-LocalFriendlyName
         }
         elseIf ($domainRole -eq 4 -or $domainRole -eq 5)
         {
-            $friendlyNames += "$($env:USERDOMAIN + '\' + $($id.trim()))"
+            $friendlyNames += "$($env:USERDOMAIN + '\' + $($id))"
         }
         elseIf ($id -notmatch '^S-')
         {
-            $friendlyNames += "$($id.trim())"
+            $friendlyNames += "$($id)"
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ If you would like to contribute to this repository, please read the DSC Resource
 ### 1.0.0.0
 
 * Initial release with the following resources:
- * UserRightsAssignment
- * SecurityTemplate
+  * UserRightsAssignment
+  * SecurityTemplate

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ If you would like to contribute to this repository, please read the DSC Resource
 
 ### Unreleased
 
+* Fixed bug in which friendly name translation may fail if user or group contains 'S-'.
+
 ### 1.3.0.0
 
 * Updated UserRightsAssignment resource to respect dynamic local accounts.

--- a/Tests/Integration/MSFT_SecurityTemplate.config.ps1
+++ b/Tests/Integration/MSFT_SecurityTemplate.config.ps1
@@ -2,7 +2,7 @@
 # create test user and security template
 $userName = "TestUser-" + ([guid]::NewGuid().guid).substring(0,6)
 $policy = 'SeTrustedCredManAccessPrivilege'
-$directoryEntry = [ADSI]"WinNT://$($Env:COMPUTERNAME)"
+$directoryEntry = [ADSI]"WinNT://$env:COMPUTERNAME,Computer"
 $user = $directoryEntry.Create("User", $userName)
 $user.setpassword('P@ssword1')
 $user.SetInfo()

--- a/Tests/Integration/MSFT_SecurityTemplate.config.ps1
+++ b/Tests/Integration/MSFT_SecurityTemplate.config.ps1
@@ -2,7 +2,7 @@
 # create test user and security template
 $userName = "TestUser-" + ([guid]::NewGuid().guid).substring(0,6)
 $policy = 'SeTrustedCredManAccessPrivilege'
-$directoryEntry = [ADSI]"WinNT://localhost"
+$directoryEntry = [ADSI]"WinNT://$($Env:COMPUTERNAME)"
 $user = $directoryEntry.Create("User", $userName)
 $user.setpassword('P@ssword1')
 $user.SetInfo()

--- a/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
+++ b/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
@@ -38,6 +38,11 @@ try
                     ConvertTo-LocalFriendlyName -SID 'user1' | Should be "$env:USERDOMAIN\user1"
                 }
 
+                It "Should return $env:USERDOMAIN\user-s-1" {                    
+                    Mock -CommandName Get-CimInstance -MockWith {return @{DomainRole=4}} -ModuleName SecurityPolicyResourceHelper
+                    ConvertTo-LocalFriendlyName -SID 'user-s-1' | Should be "$env:USERDOMAIN\user-s-1"
+                }
+
                 It 'Should ignore SID translation' {
                     Mock -CommandName Get-CimInstance -MockWith {return @{DomainRole=2}} -ModuleName SecurityPolicyResourceHelper
                     ConvertTo-LocalFriendlyName -SID 'user1' | Should be 'user1'


### PR DESCRIPTION
Updated SID matching expression within SecurityPolicyResourceHelper.psm1 to match a SID prefix, but not match user or groups containing 'S-' elsewhere in their name.

Fix for issue PowerShell/SecurityPolicyDsc#35

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/36)
<!-- Reviewable:end -->
