### PR TITLE
SecuritySetting: Trimming return values from ini (Fixes #39)

### DIFF
--- a/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
+++ b/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
@@ -50,20 +50,20 @@ function Get-IniContent
             $value = $matches[1]
             $CommentCount = $CommentCount + 1
             $name = "Comment" + $CommentCount
-            $ini[$section][$name] = $value
+            $ini[$section][$name] = $value.Trim()
             continue
         } 
         "(.+ )\s*=(.*)"  # Key
         {
             $name,$value = $matches[1..2]
-            $ini[$section][$name.Trim()] = $value
+            $ini[$section][$name.Trim()] = $value.Trim()
             # Need to replace double quotes with `"
             continue
         }
         "\`"(.*)`",(.*)$" 
         { 
             $name, $value = $matches[1..2]
-            $ini[$section][$name.Trim()] = $value
+            $ini[$section][$name.Trim()] = $value.Trim()
             continue
         }
     }


### PR DESCRIPTION
Added .Trim() to the values returned from the generated ini file.

Fix for issue PowerShell/SecurityPolicyDsc#39

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/40)
<!-- Reviewable:end -->
