### PR TITLE
Issue33

### DIFF
--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -483,7 +483,7 @@ function Get-USRPolicy
     $policyList = Get-AssignmentFriendlyNames
     $policyName = $policyList[$Policy]
 
-    $currentUserRights = ([System.IO.Path]::GetTempFileName()).Replace('tmp','inf')    
+    $currentUserRights = Join-Path -Path $env:temp -ChildPath 'CurrentUserRights.inf'   
     Write-Debug -Message ($localizedData.EchoDebugInf -f $currentUserRights)
 
     $secedit = secedit.exe /export /cfg $currentUserRights /areas $areas

--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -338,26 +338,41 @@ function Test-TargetResource
         }
     }
 
-    Write-Verbose -Message ($script:localizedData.TestIdentityIsPresentOnPolicy -f $($Identity -join","), $Policy)
+    Write-Verbose -Message ($script:localizedData.TestIdentityIsPresentOnPolicy -f $($Identity -join ","), $Policy)
 
     $accounts = @()
     switch ($Identity)
     {
-        "[Local Account]" { $accounts += (Get-CimInstance win32_useraccount -Filter "LocalAccount='True'").SID }
+        "[Local Account]" { $accounts += (Get-CimInstance Win32_UserAccount -Filter "LocalAccount='True'").SID }
         "[Local Account|Administrator]" 
         {
-            $administratorsGroup = Get-CimInstance -class win32_group -filter "SID='S-1-5-32-544'"
+            $administratorsGroup = Get-CimInstance -class Win32_Group -filter "SID='S-1-5-32-544'"
             $groupUsers = Get-CimInstance -query "select * from win32_groupuser where GroupComponent = `"Win32_Group.Domain='$($env:COMPUTERNAME)'`,Name='$($administratorsGroup.name)'`""
             [array]$usersList = $groupUsers.partcomponent | ForEach-Object { (($_ -replace '.*Win32_UserAccount.Domain="', "") -replace '",Name="', "\") -replace '"', '' }
             $users += $usersList | Where-Object {$_ -match $env:COMPUTERNAME}
-            $accounts += $users | ForEach-Object {(Get-CimInstance win32_useraccount -Filter "Caption='$($_.Replace("\", "\\"))'").SID}
+            $accounts += $users | ForEach-Object {(Get-CimInstance Win32_UserAccount -Filter "Caption='$($_.Replace("\", "\\"))'").SID}
         }
-        Default { $accounts += $_} 
+        Default
+        {
+            # To test for identities we have to do a dump of the security database the dump does not specify the 
+            # computerName on local accounts. So we need to test for that scenario.
+            if ( $_ -match '\\' -and $_ -notmatch 'Builtin')
+            {
+                if ( Test-IsLocalAccount -Identity $_ )
+                {
+                    $accounts += ( $_ -split '\\' )[-1]
+                }
+            }
+            else
+            {
+                $accounts += ConvertTo-LocalFriendlyName $(($_) -replace '\*')
+            }    
+        } 
     }
         
     if ($Ensure -eq "Present")
-    {
-        $usersWithoutRight = $accounts | Where-Object {$_ -notin $userRights.Identity}
+    {        
+        $usersWithoutRight = $accounts | Where-Object { $_ -notin $userRights.Identity }
         if ($usersWithoutRight)
         {
             Write-Verbose "$($usersWithoutRight -join ",") do not have Privilege ($Policy)"
@@ -533,6 +548,30 @@ Revision=1
 "@
 
     $null = Out-File -InputObject $infTemplate -FilePath $FilePath -Encoding unicode
+}
+<#
+    .SYNOPSIS
+        Test if an account is a local account
+    .PARAMETER Identity
+        The identity of the user or group to be added or removed from the user rights assignment
+#>
+function Test-IsLocalAccount
+{
+    param
+    (
+        [string]$Identity
+    )
+
+    $localAccounts = Get-CimInstance Win32_UserAccount -Filter "LocalAccount='True'"
+
+    if ( $localAccounts.Caption -contains $Identity )
+    {
+        return $true
+    }
+    else
+    {
+        return $true
+    }
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ If you would like to contribute to this repository, please read the DSC Resource
 ### Unreleased
 
 * Fixed bug in which friendly name translation may fail if user or group contains 'S-'.
+* Fixed bug identified in issue 33 and 34 where Test-TargetResource would return false but was true
 
 ### 1.3.0.0
 


### PR DESCRIPTION
Fixed issue where Test-TargetResource would incorrectly return false inside of Set-TargetResource.  Two scenarios have been identified to cause this:
1. An asterisk is prepended to a SID (ex. "*S-1-5-32-544")
2. A local account is specified with a computer name (ex. localhost\TestUser1)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/44)
<!-- Reviewable:end -->
