### PR TITLE
Updated tests so the PR that fixes Test-IsLocalAccount pass. 

### DIFF
--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -230,7 +230,7 @@ function Set-TargetResource
     
     # Verify secedit command was successful
 
-    if (Test-TargetResource -Identity $Identity -Policy $Policy)
+    if ( Test-TargetResource -Identity $Identity -Policy $Policy -Ensure $Ensure )
     {
         Write-Verbose -Message ($script:localizedData.TaskSuccess)
         Write-Verbose "$(($idsToAdd -join ",")) successfully given Rights ($Policy)"
@@ -361,6 +361,10 @@ function Test-TargetResource
                 if ( Test-IsLocalAccount -Identity $_ )
                 {
                     $accounts += ( $_ -split '\\' )[-1]
+                }
+                else
+                {
+                    $accounts += ConvertTo-LocalFriendlyName $_
                 }
             }
             else

--- a/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
+++ b/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
@@ -41,6 +41,12 @@ try
                 PolicyFriendlyName = $testParameters.Policy
             }
 
+            $mockUSRDoesExist = [PSObject]@{
+                Policy = 'Access_Credential_Manager_as_a_trusted_caller'
+                Identity = 'contoso\testUser1','contoso\TestUser2'
+                PolicyFriendlyName = $testParameters.Policy
+            }
+
             $mockNullIdentity = [PSObject] @{
                 Policy = 'Access_Credential_Manager_as_a_trusted_caller'
                 Identity = $null
@@ -70,7 +76,7 @@ try
         #region Function Test-TargetResource
         Describe "Test-TargetResource" {
             Context 'Identity does exist and should' {
-                Mock -CommandName  Get-USRPolicy -MockWith {$mockGetUSRPolicyResult}
+                Mock -CommandName  Get-USRPolicy -MockWith {$mockUSRDoesExist}
 
                 It 'Should return true' {
                     $testResult = Test-TargetResource @testParameters
@@ -218,3 +224,4 @@ finally
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion
 }
+


### PR DESCRIPTION
Fixed issue when Set-TargetResource would falsely error when Ensure=Absent

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/50)
<!-- Reviewable:end -->
