### PR TITLE
Refactor user rights

### DIFF
--- a/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
+++ b/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
@@ -34,7 +34,8 @@ function Get-IniContent
     param
     (
         [Parameter(Mandatory=$true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName=$true)]
-        [System.String]$Path
+        [System.String]
+        $Path
     )
 
     $ini = @{}
@@ -99,10 +100,12 @@ function Set-SecuritySettings
     param
     (
         [Parameter(Mandatory=$true)]
-        [string]$secDB,
+        [string]
+        $secDB,
 
         [Parameter(Mandatory=$true)]
-        [string]$tmpFile
+        [string]
+        $tmpFile
     )
     
     $PowerShellProcess = new-object System.Diagnostics.Process
@@ -123,7 +126,8 @@ function Get-TargetResource
     (
         [Parameter(Mandatory=$true)]
         [ValidateSet("MinimumPasswordAge","MaximumPasswordAge","MinimumPasswordLength","PasswordComplexity","PasswordHistorySize","LockoutBadCount","ForceLogoffWhenHourExpire","NewAdministratorName","NewGuestName","ClearTextPassword","LSAAnonymousNameLookup","EnableAdminAccount","EnableGuestAccount","ResetLockoutCount","LockoutDuration","MaxServiceAge","MaxTicketAge","MaxRenewAge","MaxClockSkew","TicketValidateClient")]
-        [System.String]$Name
+        [System.String]
+        $Name
     )
     
     $ini = Get-SecuritySettings
@@ -147,77 +151,101 @@ function Set-TargetResource
     (
         [Parameter()]
         [ValidateRange(-1, 999)]
-        [System.Int16]$MinimumPasswordAge,
+        [System.Int16]
+        $MinimumPasswordAge,
         
         [Parameter()]
         [ValidateRange(0,999)]
-        [System.UInt16]$MaximumPasswordAge,
+        [System.UInt16]
+        $MaximumPasswordAge,
 
         [Parameter()]
-        [System.UInt16]$MinimumPasswordLength,
+        [System.UInt16]
+        $MinimumPasswordLength,
         
         [Parameter()]
-        [System.UInt16]$PasswordComplexity,
+        [System.UInt16]
+        $PasswordComplexity,
         
         [Parameter()]
-        [System.UInt16]$PasswordHistorySize,
+        [System.UInt16]
+        $PasswordHistorySize,
         
         [Parameter()]
-        [System.UInt16]$LockoutBadCount,
+        [System.UInt16]
+        $LockoutBadCount,
         
         [Parameter()]
-        [System.UInt16]$ForceLogoffWhenHourExpire,
+        [System.UInt16]
+        $ForceLogoffWhenHourExpire,
         
         [Parameter()]
-        [System.String]$NewAdministratorName,
+        [System.String]
+        $NewAdministratorName,
         
         [Parameter()]
-        [System.String]$NewGuestName,
+        [System.String]
+        $NewGuestName,
 
         [Parameter()]
-        [System.UInt16]$ClearTextPassword,
+        [System.UInt16]
+        $ClearTextPassword,
         
         [Parameter()]
-        [System.UInt16]$LSAAnonymousNameLookup,
+        [System.UInt16]
+        $LSAAnonymousNameLookup,
         
         [Parameter()]
-        [System.UInt16]$EnableAdminAccount,
+        [System.UInt16]
+        $EnableAdminAccount,
         
         [Parameter()]
-        [System.UInt16]$EnableGuestAccount,
+        [System.UInt16]
+        $EnableGuestAccount,
 
         [Parameter()]
-        [System.Int16]$ResetLockoutCount,
+        [System.Int16]
+        $ResetLockoutCount,
         
         [Parameter()]
         [ValidateRange(-1, 99999)]
         [ValidateScript({$_ -ne 0})]
-        [System.Int16]$LockoutDuration,
+        [System.Int16]
+        $LockoutDuration,
         
         [Parameter()]
         [ValidateScript({$_ -ge 10})]
-        [System.UInt16]$MaxServiceAge,
+        [System.UInt16]
+        $MaxServiceAge,
         
         [Parameter()]
         [ValidateRange(0,99999)]
-        [System.UInt16]$MaxTicketAge,
+        [System.UInt16]
+        $MaxTicketAge,
         
         [Parameter()]
         [ValidateRange(0,99999)]
-        [System.UInt16]$MaxRenewAge,
+        [System.UInt16]
+        $MaxRenewAge,
         
         [Parameter()]
         [ValidateRange(0,99999)]
-        [System.UInt16]$MaxClockSkew,
-        [System.UInt16]$TicketValidateClient,
+        [System.UInt16]
+        $MaxClockSkew,
+
+        [Parameter()]
+        [System.UInt16]
+        $TicketValidateClient,
 
         [Parameter()]
         [ValidateSet("Present","Absent")]
-        [System.String]$Ensure = "Present",
+        [System.String]
+        $Ensure = "Present",
 
         [Parameter(Mandatory=$true)]
         [ValidateSet("MinimumPasswordAge","MaximumPasswordAge","MinimumPasswordLength","PasswordComplexity","PasswordHistorySize","LockoutBadCount","ForceLogoffWhenHourExpire","NewAdministratorName","NewGuestName","ClearTextPassword","LSAAnonymousNameLookup","EnableAdminAccount","EnableGuestAccount","ResetLockoutCount","LockoutDuration","MaxServiceAge","MaxTicketAge","MaxRenewAge","MaxClockSkew","TicketValidateClient")]
-        [System.String]$Name
+        [System.String]
+        $Name
     )
     
     if (@($PSBoundParameters.Keys.Where({$_ -notin "Name", "Ensure"})).Count -eq 0)
@@ -295,77 +323,100 @@ function Test-TargetResource
     (
         [Parameter()]
         [ValidateRange(-1, 999)]
-        [System.Int16]$MinimumPasswordAge,
+        [System.Int16]
+        $MinimumPasswordAge,
         
         [Parameter()]
         [ValidateRange(0,999)]
-        [System.UInt16]$MaximumPasswordAge,
+        [System.UInt16]
+        $MaximumPasswordAge,
 
         [Parameter()]
-        [System.UInt16]$MinimumPasswordLength,
+        [System.UInt16]
+        $MinimumPasswordLength,
         
         [Parameter()]
-        [System.UInt16]$PasswordComplexity,
+        [System.UInt16]
+        $PasswordComplexity,
         
         [Parameter()]
-        [System.UInt16]$PasswordHistorySize,
+        [System.UInt16]
+        $PasswordHistorySize,
         
         [Parameter()]
-        [System.UInt16]$LockoutBadCount,
+        [System.UInt16]
+        $LockoutBadCount,
         
         [Parameter()]
-        [System.UInt16]$ForceLogoffWhenHourExpire,
+        [System.UInt16]
+        $ForceLogoffWhenHourExpire,
         
         [Parameter()]
-        [System.String]$NewAdministratorName,
+        [System.String]
+        $NewAdministratorName,
         
         [Parameter()]
-        [System.String]$NewGuestName,
+        [System.String]
+        $NewGuestName,
 
         [Parameter()]
-        [System.UInt16]$ClearTextPassword,
+        [System.UInt16]
+        $ClearTextPassword,
         
         [Parameter()]
-        [System.UInt16]$LSAAnonymousNameLookup,
+        [System.UInt16]
+        $LSAAnonymousNameLookup,
         
         [Parameter()]
-        [System.UInt16]$EnableAdminAccount,
+        [System.UInt16]
+        $EnableAdminAccount,
         
         [Parameter()]
-        [System.UInt16]$EnableGuestAccount,
+        [System.UInt16]
+        $EnableGuestAccount,
 
         [Parameter()]
-        [System.Int16]$ResetLockoutCount,
+        [System.Int16]
+        $ResetLockoutCount,
         
         [Parameter()]
         [ValidateRange(-1, 99999)]
         [ValidateScript({$_ -ne 0})]
-        [System.Int16]$LockoutDuration,
+        [System.Int16]
+        $LockoutDuration,
         
         [Parameter()]
         [ValidateScript({$_ -ge 10})]
-        [System.UInt16]$MaxServiceAge,
+        [System.UInt16]
+        $MaxServiceAge,
         
         [Parameter()]
         [ValidateRange(0,99999)]
-        [System.UInt16]$MaxTicketAge,
+        [System.UInt16]
+        $MaxTicketAge,
         
         [Parameter()]
         [ValidateRange(0,99999)]
-        [System.UInt16]$MaxRenewAge,
+        [System.UInt16]
+        $MaxRenewAge,
         
         [Parameter()]
         [ValidateRange(0,99999)]
-        [System.UInt16]$MaxClockSkew,
-        [System.UInt16]$TicketValidateClient,
+        [System.UInt16]
+        $MaxClockSkew,
+
+        [System.UInt16]
+        TicketValidateClient,
 
         [Parameter()]
         [ValidateSet("Present","Absent")]
-        [System.String]$Ensure = "Present",
+        [System.String]
+        $Ensure = "Present",
 
         [Parameter(Mandatory=$true)]
         [ValidateSet("MinimumPasswordAge","MaximumPasswordAge","MinimumPasswordLength","PasswordComplexity","PasswordHistorySize","LockoutBadCount","ForceLogoffWhenHourExpire","NewAdministratorName","NewGuestName","ClearTextPassword","LSAAnonymousNameLookup","EnableAdminAccount","EnableGuestAccount","ResetLockoutCount","LockoutDuration","MaxServiceAge","MaxTicketAge","MaxRenewAge","MaxClockSkew","TicketValidateClient")]
-        [System.String]$Name
+        [System.String]
+        $Name
     )
 
     if (@($PSBoundParameters.Keys.Where({$_ -notin "Name", "Ensure"})).Count -eq 0)

--- a/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
+++ b/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
@@ -33,7 +33,7 @@ function Get-IniContent
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory=$true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName=$true)]
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true)]
         [System.String]
         $Path
     )
@@ -99,11 +99,11 @@ function Set-SecuritySettings
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]
         $secDB,
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]
         $tmpFile
     )
@@ -124,7 +124,7 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("MinimumPasswordAge","MaximumPasswordAge","MinimumPasswordLength","PasswordComplexity","PasswordHistorySize","LockoutBadCount","ForceLogoffWhenHourExpire","NewAdministratorName","NewGuestName","ClearTextPassword","LSAAnonymousNameLookup","EnableAdminAccount","EnableGuestAccount","ResetLockoutCount","LockoutDuration","MaxServiceAge","MaxTicketAge","MaxRenewAge","MaxClockSkew","TicketValidateClient")]
         [System.String]
         $Name
@@ -242,7 +242,7 @@ function Set-TargetResource
         [System.String]
         $Ensure = "Present",
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("MinimumPasswordAge","MaximumPasswordAge","MinimumPasswordLength","PasswordComplexity","PasswordHistorySize","LockoutBadCount","ForceLogoffWhenHourExpire","NewAdministratorName","NewGuestName","ClearTextPassword","LSAAnonymousNameLookup","EnableAdminAccount","EnableGuestAccount","ResetLockoutCount","LockoutDuration","MaxServiceAge","MaxTicketAge","MaxRenewAge","MaxClockSkew","TicketValidateClient")]
         [System.String]
         $Name
@@ -414,7 +414,7 @@ function Test-TargetResource
         [System.String]
         $Ensure = "Present",
 
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("MinimumPasswordAge","MaximumPasswordAge","MinimumPasswordLength","PasswordComplexity","PasswordHistorySize","LockoutBadCount","ForceLogoffWhenHourExpire","NewAdministratorName","NewGuestName","ClearTextPassword","LSAAnonymousNameLookup","EnableAdminAccount","EnableGuestAccount","ResetLockoutCount","LockoutDuration","MaxServiceAge","MaxTicketAge","MaxRenewAge","MaxClockSkew","TicketValidateClient")]
         [System.String]
         $Name

--- a/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
+++ b/DSCResources/MSFT_SecuritySetting/MSFT_SecuritySetting.psm1
@@ -405,8 +405,9 @@ function Test-TargetResource
         [System.UInt16]
         $MaxClockSkew,
 
+        [Parameter()]
         [System.UInt16]
-        TicketValidateClient,
+        $TicketValidateClient,
 
         [Parameter()]
         [ValidateSet("Present","Absent")]

--- a/DSCResources/MSFT_SecurityTemplate/MSFT_SecurityTemplate.psm1
+++ b/DSCResources/MSFT_SecurityTemplate/MSFT_SecurityTemplate.psm1
@@ -179,6 +179,7 @@ function Format-SecurityPolicyFile
     [CmdletBinding()]
     param
     (
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Path
     )
@@ -208,6 +209,7 @@ function Get-SecurityTemplate
     [CmdletBinding()]   
     param
     (
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Path
     )

--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -70,16 +70,18 @@ function Get-TargetResource
         [System.String]
         $Policy,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()]
         [AllowEmptyString()]      
         [System.String[]]
         $Identity,
 
+        [Parameter()]
         [ValidateSet("Present","Absent")]
         [System.String]
         $Ensure = "Present",
 
+        [Parameter()]
         [System.Boolean]
         $Force
     )
@@ -87,12 +89,11 @@ function Get-TargetResource
     $userRightPolicy = Get-UserRightPolicy -Name $Policy
 
     Write-Verbose -Message "Policy: $($userRightPolicy.FriendlyName). Identity: $($userRightPolicy.Identity)"
-    $returnValue = @{
-        Policy         = $userRightPolicy.FriendlyName
-        Identity       = $userRightPolicy.Identity
+    
+    return  @{
+        Policy   = $userRightPolicy.FriendlyName
+        Identity = $userRightPolicy.Identity
     }
-
-    $returnValue
 }
 
 <#
@@ -159,16 +160,18 @@ function Set-TargetResource
         [System.String]
         $Policy,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()]
         [AllowEmptyString()]
         [System.String[]]
         $Identity,
 
+        [Parameter()]
         [ValidateSet("Present","Absent")]
         [System.String]
         $Ensure = "Present",
 
+        [Parameter()]
         [System.Boolean]
         $Force = $false
     )
@@ -312,16 +315,18 @@ function Test-TargetResource
         [System.String]
         $Policy,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()] 
         [AllowEmptyString()]               
         [System.String[]]
         $Identity,
 
+        [Parameter()]
         [ValidateSet("Present","Absent")]
         [System.String]
         $Ensure = "Present",
 
+        [Parameter()]
         [System.Boolean]
         $Force
     )
@@ -504,7 +509,8 @@ function Get-UserRightConstant
 {
     [OutputType([string])]
     [CmdletBinding()]
-    Param (
+    Param 
+    (
         [Parameter(Mandatory = $true)]
         [System.String]
         $Policy
@@ -533,12 +539,15 @@ function Out-UserRightsInf
     [CmdletBinding()]
     param
     (
+        [Parameter(Mandatory = $true)]
         [System.String]
         $InfPolicy,
 
+        [Parameter(Mandatory = $true)]
         [System.String]
         $UserList,
 
+        [Parameter(Mandatory = $true)]
         [System.String]
         $FilePath
     )

--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -420,10 +420,10 @@ function Test-TargetResource
 <#
     .SYNOPSIS
         Returns an object of the identities assigned to a user rights assignment
-    .PARAMETER Policy
+    .PARAMETER Name
         Name of the policy to inspect
     .EXAMPLE
-        Get-UserRightPolicy -Policy Create_a_token_object
+        Get-UserRightPolicy -Name Create_a_token_object
 #>
 function Get-UserRightPolicy
 {
@@ -581,4 +581,3 @@ function Test-IsLocalAccount
 }
 
 Export-ModuleMember -Function *-TargetResource
-

--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -317,7 +317,7 @@ function Test-TargetResource
 
         [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()] 
-        [AllowEmptyString()]               
+        [AllowEmptyString()]
         [System.String[]]
         $Identity,
 
@@ -574,7 +574,9 @@ function Test-IsLocalAccount
 {
     param
     (
-        [string]$Identity
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Identity
     )
 
     $localAccounts = Get-CimInstance Win32_UserAccount -Filter "LocalAccount='True'"

--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -173,7 +173,7 @@ function Set-TargetResource
         $Force = $false
     )
     
-    $UserRightsFriendlyName = Get-UserRightsFriendlyName -Policy $Policy
+    $userRightConstant = Get-UserRightConstant -Policy $Policy
 
     $script:seceditOutput = "$env:TEMP\Secedit-OutPut.txt"
     $userRightsToAddInf   = "$env:TEMP\userRightsToAdd.inf" 
@@ -226,7 +226,7 @@ function Set-TargetResource
         Write-Verbose -Message ($script:localizedData.GrantingPolicyRightsToIds -f $Policy, $idsToAdd)
     }
        
-    Out-UserRightsInf -InfPolicy $UserRightsFriendlyName -UserList $idsToAdd -FilePath $userRightsToAddInf
+    Out-UserRightsInf -InfPolicy $userRightConstant -UserList $idsToAdd -FilePath $userRightsToAddInf
     Write-Debug -Message ($script:localizedData.EchoDebugInf -f $userRightsToAddInf)
 
     Write-Verbose "Attempting to Set ($($idstoAdd -join ",")) for Policy $($Policy))"
@@ -483,14 +483,14 @@ function Get-UserRightsPolicy
         $Policy
     )
 
-    $userRightsFriendlyName = Get-UserRightsFriendlyName -Policy $Policy
+    $userRightConstant = Get-UserRightConstant -Policy $Policy
 
     $userRights = Get-SecurityPolicy -Area 'USER_RIGHTS'  
 
     [PSObject]@{
-        Policy = $Policy
-        PolicyFriendlyName = $userRightsFriendlyName
-        Identity = $userRights[$userRightsFriendlyName]
+        Policy = $userRightConstant
+        PolicyFriendlyName = $Policy
+        Identity = $userRights[$userRightConstant]
     }
 }
 
@@ -500,7 +500,7 @@ function Get-UserRightsPolicy
     .PARAMETER Policy
         Name of the policy to get friendly name for. 
 #>
-function Get-UserRightsFriendlyName
+function Get-UserRightConstant
 {
     [OutputType([string])]
     [CmdletBinding()]

--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -77,12 +77,14 @@ function Get-TargetResource
         $Identity,
 
         [ValidateSet("Present","Absent")]
-        [System.String]$Ensure = "Present",
+        [System.String]
+        $Ensure = "Present",
 
-        [System.Boolean]$Force = $false
+        [System.Boolean]
+        $Force
     )
     
-    $usrResult = Get-USRPolicy -Policy $Policy -Areas USER_RIGHTS
+    $usrResult = Get-UserRightsPolicy -Policy $Policy
 
     Write-Verbose "Policy: $($usrResult.PolicyFriendlyName). Identity: $($usrResult.Identity)"
     $returnValue = @{

--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -326,7 +326,7 @@ function Test-TargetResource
         $Force
     )
     
-    $currentUserRights = Get-USRPolicy -Policy $Policy
+    $currentUserRights = Get-UserRightsPolicy -Policy $Policy
 
     if ( Test-IdentityIsNull -Identity $Identity )
     {

--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -544,6 +544,8 @@ function Out-UserRightsInf
         $InfPolicy,
 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [AllowNull()]
         [System.String]
         $UserList,
 

--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -297,7 +297,7 @@ function Test-IdentityIsNull
     [CmdletBinding()]
     param
     ( 
-        [System.String]
+        [System.String[]]
         $Identity
     )
 

--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -304,6 +304,8 @@ function Test-IdentityIsNull
     param
     ( 
         [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()] 
+        [AllowEmptyString()]
         [System.String[]]
         $Identity
     )

--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -133,8 +133,7 @@ function Get-SecurityPolicy
         "(.+?)\s*=(.*)" # Key
         {
             $name,$value =  $matches[1..2] -replace "\*"
-            $policyConfiguration[$section][$name] = $value -split ','
-            #$policyConfiguration[$section][$name] = @(ConvertTo-LocalFriendlyName $($value -split ','))
+            $policyConfiguration[$section][$name] = @(ConvertTo-LocalFriendlyName $($value -split ','))
         }
     }
 

--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -306,6 +306,7 @@ function Test-IdentityIsNull
         [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()] 
         [AllowEmptyString()]
+        [AllowNull()]
         [System.String[]]
         $Identity
     )

--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -25,7 +25,6 @@ function Get-LocalizedData
         [ValidateNotNullOrEmpty()]
         [String]
         $HelperName
-
     )
 
     # With the helper module just update the name and path variables as if it were a resource. 
@@ -74,12 +73,15 @@ function Invoke-Secedit
     [CmdletBinding()]
     param
     (
+        [Parameter(Mandatory = $true)]
         [System.String]
         $UserRightsToAddInf,
 
+        [Parameter(Mandatory = $true)]
         [System.String]
         $SeceditOutput,
 
+        [Parameter()]
         [System.Management.Automation.SwitchParameter]
         $OverWrite
     )
@@ -103,7 +105,7 @@ function Get-SecurityPolicy
     [CmdletBinding()]
     param
     (       
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("SECURITYPOLICY","GROUP_MGMT","USER_RIGHTS","REGKEYS","FILESTORE","SERVICES")]
         [System.String]
         $Area
@@ -166,6 +168,7 @@ function Get-UserRightsAssignment
     [CmdletBinding()]
     param
     (
+        [Parameter(Mandatory = $true)]
         [System.String]
         $FilePath
     )
@@ -209,6 +212,7 @@ function ConvertTo-LocalFriendlyName
     [CmdletBinding()]
     param
     (
+        [Parameter(Mandatory = $true)]
         [System.String[]]
         $SID
     )
@@ -258,7 +262,7 @@ function Get-DomainRole
 {
     [OutputType([String])]
     [CmdletBinding()]
-    param( )
+    param()
 
     $domainRoleInt = (Get-CimInstance -ClassName Win32_ComputerSystem).DomainRole
 
@@ -299,6 +303,7 @@ function Test-IdentityIsNull
     [CmdletBinding()]
     param
     ( 
+        [Parameter(Mandatory = $true)]
         [System.String[]]
         $Identity
     )

--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -290,6 +290,8 @@ function Get-DomainRole
 <#
     .SYNOPSIS
         Tests if the provided Identity is null
+    .PARAMETER Identity
+        The identity string to test
 #>
 function Test-IdentityIsNull
 {

--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -70,6 +70,7 @@ function Get-LocalizedData
 #>
 function Invoke-Secedit
 {
+    [OutputType([void])]
     [CmdletBinding()]
     param
     (

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ If you would like to contribute to this repository, please read the DSC Resource
 ## Versions
 
 ### Unreleased
+* Refactored user rights assignment to read and test easier. 
 
 ### 1.4.0.0
 

--- a/Tests/Unit/MSFT_SecurityTemplate.tests.ps1
+++ b/Tests/Unit/MSFT_SecurityTemplate.tests.ps1
@@ -85,8 +85,8 @@ try
                 {                        
                     $mockFalseResults = Set-HashValue -HashTable $modifiedMockResults -Key $key -NewValue NoIdentity
                     
-                    Mock -CommandName Get-UserRightsAssignment -MockWith {return $mockResults} -ParameterFilter {$FilePath -like "*Temp*inf*inf"}
-                    Mock -CommandName Get-UserRightsAssignment -MockWith {return $mockFalseResults} -ParameterFilter {$FilePath -eq $testParameters.Path} 
+                    Mock -CommandName Get-SecurityPolicy -MockWith {return $mockResults} -ParameterFilter {$FilePath -like "*Temp*inf*inf"}
+                    Mock -CommandName Get-SecurityPolicy -MockWith {return $mockFalseResults} -ParameterFilter {$FilePath -eq $testParameters.Path} 
                     Mock -CommandName Test-Path -MockWith {$true}
 
                     It "Test method should return false when testing $key" {  
@@ -119,10 +119,10 @@ try
                 $mockResults = Import-Clixml -Path "$PSScriptRoot..\..\..\Misc\MockObjects\MockResults.xml"
 
                 It 'Should return true when in a desired state' {
-                    Mock -CommandName Get-UserRightsAssignment -MockWith {$mockResults}
+                    Mock -CommandName Get-SecurityPolicy -MockWith {$mockResults}
                     Mock -CommandName Get-SecurityTemplate -MockWith {}
                     Mock -CommandName Test-Path -MockWith {$true}
-                    Mock -CommandName Get-UserRightsAssignment -MockWith {}
+                    Mock -CommandName Get-SecurityPolicy -MockWith {}
                     Mock -CommandName Get-Module -MockWith {}
                     
                     if($securityModulePresent)

--- a/Tests/Unit/MSFT_SecurityTemplate.tests.ps1
+++ b/Tests/Unit/MSFT_SecurityTemplate.tests.ps1
@@ -85,8 +85,8 @@ try
                 {                        
                     $mockFalseResults = Set-HashValue -HashTable $modifiedMockResults -Key $key -NewValue NoIdentity
                     
-                    Mock -CommandName Get-SecurityPolicy -MockWith {return $mockResults} -ParameterFilter {$FilePath -like "*Temp*inf*inf"}
-                    Mock -CommandName Get-SecurityPolicy -MockWith {return $mockFalseResults} -ParameterFilter {$FilePath -eq $testParameters.Path} 
+                    Mock -CommandName Get-UserRightsAssignment -MockWith {return $mockResults} -ParameterFilter {$FilePath -like "*Temp*inf*inf"}
+                    Mock -CommandName Get-UserRightsAssignment -MockWith {return $mockFalseResults} -ParameterFilter {$FilePath -eq $testParameters.Path} 
                     Mock -CommandName Test-Path -MockWith {$true}
 
                     It "Test method should return false when testing $key" {  
@@ -119,10 +119,10 @@ try
                 $mockResults = Import-Clixml -Path "$PSScriptRoot..\..\..\Misc\MockObjects\MockResults.xml"
 
                 It 'Should return true when in a desired state' {
-                    Mock -CommandName Get-SecurityPolicy -MockWith {$mockResults}
+                    Mock -CommandName Get-UserRightsAssignment -MockWith {$mockResults}
                     Mock -CommandName Get-SecurityTemplate -MockWith {}
                     Mock -CommandName Test-Path -MockWith {$true}
-                    Mock -CommandName Get-SecurityPolicy -MockWith {}
+                    Mock -CommandName Get-UserRightsAssignment -MockWith {}
                     Mock -CommandName Get-Module -MockWith {}
                     
                     if($securityModulePresent)

--- a/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
+++ b/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
@@ -195,7 +195,7 @@ try
         #region Function Get-USRPolicy
         Describe "Get-UserRightsPolicy" {
             Mock -CommandName Get-UserRightsFriendlyName -MockWith { 'Access_Credential_Manager_as_a_trusted_caller' }
-            Mock -CommandName Get-UserRightsAssignment   -MockWith { 'SeTrustedCredManAccessPrivilege' = "foo" }
+            Mock -CommandName Get-UserRightsAssignment   -MockWith { @{'SeTrustedCredManAccessPrivilege' = "foo" }}
 
             $getUsrResult = Get-UserRightsPolicy -Policy 'Access_Credential_Manager_as_a_trusted_caller'
 
@@ -208,8 +208,7 @@ try
             It 'Should match Identity' {
                 $getUsrResult.Identity | Should be 'foo'
             }
-
-            It 'Should call expected mnocks' {
+            It 'Should call expected mocks' {
                 Assert-MockCalled -CommandName Get-UserRightsFriendlyName
                 Assert-MockCalled -CommandName Get-UserRightsAssignment
             }

--- a/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
+++ b/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
@@ -211,6 +211,14 @@ try
                 Assert-MockCalled -CommandName Get-SecurityPolicy
             }
         }
+
+        Describe 'Get-UserRightConstant' {
+
+            $constant = Get-UserRightConstant -Policy 'Access_Credential_Manager_as_a_trusted_caller'
+            It 'Should match policy' {
+                $constant | Should Be 'SeTrustedCredManAccessPrivilege'
+            }
+        }
         #endregion    
     }
     #endregion

--- a/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
+++ b/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
@@ -57,7 +57,7 @@ try
         #region Function Get-TargetResource
         Describe "Get-TargetResource" {  
             Context 'Identity should match on Policy' {
-                Mock -CommandName Get-USRPolicy -MockWith {return @($testParameters)}
+                Mock -CommandName Get-UserRightsPolicy -MockWith {return @($testParameters)}
                 Mock -CommandName Test-TargetResource -MockWith {$false}
 
                 It 'Should not match Identity' {                    
@@ -67,7 +67,7 @@ try
                 }
 
                 It 'Should call expected Mocks' {
-                    Assert-MockCalled -CommandName Get-USRPolicy -Exactly 1
+                    Assert-MockCalled -CommandName Get-UserRightsPolicy -Exactly 1
                 }
             }
         }
@@ -76,7 +76,7 @@ try
         #region Function Test-TargetResource
         Describe "Test-TargetResource" {
             Context 'Identity does exist and should' {
-                Mock -CommandName  Get-USRPolicy -MockWith {$mockUSRDoesExist}
+                Mock -CommandName  Get-UserRightsPolicy -MockWith {$mockUSRDoesExist}
 
                 It 'Should return true' {
                     $testResult = Test-TargetResource @testParameters
@@ -85,12 +85,12 @@ try
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-MockCalled -CommandName Get-USRPolicy -Exactly 1
+                    Assert-MockCalled -CommandName Get-UserRightsPolicy -Exactly 1
                 }
             }
 
             Context 'Identity does not exist' {
-                Mock -CommandName Get-USRPolicy -MockWith {$mockUSRDoesNotExist}
+                Mock -CommandName Get-UserRightsPolicy -MockWith {$mockUSRDoesNotExist}
 
                 It 'Shoud return false' {
                    $testResult = Test-TargetResource @testParameters
@@ -99,7 +99,7 @@ try
             }
 
             Context 'Identity does not exist but should' {
-                Mock -CommandName Get-USRPolicy -MockWith {}
+                Mock -CommandName Get-UserRightsPolicy -MockWith {}
 
                 It 'Should return false' {
                     $testResult = Test-TargetResource @testParameters
@@ -108,20 +108,20 @@ try
                 }
 
                 It 'Should call expected mocks' {
-                    Assert-MockCalled -CommandName Get-USRPolicy -Exactly 1
+                    Assert-MockCalled -CommandName Get-UserRightsPolicy -Exactly 1
                 } 
             }
 
             Context 'Identity is NULL and should be' {
                 It 'Should return true' {
-                    Mock -CommandName Get-USRPolicy -MockWith {$mockNullIdentity}
+                    Mock -CommandName Get-UserRightsPolicy -MockWith {$mockNullIdentity}
                     $testResult = Test-TargetResource -Policy Access_Credential_Manager_as_a_trusted_caller -Identity ""
 
                     $testResult | Should be $true
                 }
 
                 It 'Should return false' {
-                    Mock -CommandName Get-USRPolicy -MockWith {$mockGetUSRPolicyResult}
+                    Mock -CommandName Get-UserRightsPolicy -MockWith {$mockGetUSRPolicyResult}
                     $testResult = Test-TargetResource -Policy Access_Credential_Manager_as_a_trusted_caller -Identity ""
 
                     $testResult | Should be $false
@@ -137,7 +137,7 @@ try
                 It 'Should return True when a computerName is specified with a local account' {   
                                  
                     $mockGetUSRPolicyResult.Identity = 'testuser1'
-                    Mock -CommandName Get-USRPolicy -MockWith {$mockGetUSRPolicyResult}
+                    Mock -CommandName Get-UserRightsPolicy -MockWith {$mockGetUSRPolicyResult}
                     $testResult = Test-TargetResource -Policy 'Access_Credential_Manager_as_a_trusted_caller' -Identity 'localhost\testuser1'
                     $testResult | Should be $true
                 }
@@ -145,7 +145,7 @@ try
                 It 'Should return True when a SID is used for Identity' {
 
                     $mockGetUSRPolicyResult.Identity = "BUILTIN\Administrators"
-                    Mock -CommandName Get-USRPolicy -MockWith {$mockGetUSRPolicyResult}
+                    Mock -CommandName Get-UserRightsPolicy -MockWith {$mockGetUSRPolicyResult}
                     $testResult = Test-TargetResource -Policy 'Access_Credential_Manager_as_a_trusted_caller' -Identity "*S-1-5-32-544"
                     $testResult | Should be $true
                 }
@@ -192,7 +192,7 @@ try
             }
         }
         #endregion
-        #region Function Get-USRPolicy
+        #region Function Get-UserRightsPolicy
         Describe "Get-UserRightsPolicy" {
             Mock -CommandName Get-UserRightsFriendlyName -MockWith { 'Access_Credential_Manager_as_a_trusted_caller' }
             Mock -CommandName Get-SecurityPolicy   -MockWith { @{'SeTrustedCredManAccessPrivilege' = "foo" }}

--- a/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
+++ b/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
@@ -193,11 +193,11 @@ try
         }
         #endregion
         #region Function Get-USRPolicy
-        Describe "Get-USRPolicy" {
-            Mock -CommandName Get-AssignmentFriendlyNames -MockWith { @{'Access_Credential_Manager_as_a_trusted_caller' = 'SeTrustedCredManAccessPrivilege'}}
-            Mock -CommandName Get-UserRightsAssignment -MockWith {@{'Privilege Rights' = @{'SeTrustedCredManAccessPrivilege' = "foo"}}}
+        Describe "Get-UserRightsPolicy" {
+            Mock -CommandName Get-UserRightsFriendlyName -MockWith { 'Access_Credential_Manager_as_a_trusted_caller' }
+            Mock -CommandName Get-UserRightsAssignment   -MockWith { 'SeTrustedCredManAccessPrivilege' = "foo" }
 
-            $getUsrResult = Get-USRPolicy -Policy 'Access_Credential_Manager_as_a_trusted_caller' -Areas USER_Rights
+            $getUsrResult = Get-UserRightsPolicy -Policy 'Access_Credential_Manager_as_a_trusted_caller'
 
             It 'Should match policy' {
                 $getUsrResult.Policy | Should Be 'SeTrustedCredManAccessPrivilege'
@@ -210,7 +210,7 @@ try
             }
 
             It 'Should call expected mnocks' {
-                Assert-MockCalled -CommandName Get-AssignmentFriendlyNames
+                Assert-MockCalled -CommandName Get-UserRightsFriendlyName
                 Assert-MockCalled -CommandName Get-UserRightsAssignment
             }
         }

--- a/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
+++ b/Tests/Unit/MSFT_UserRightsAssignment.tests.ps1
@@ -195,7 +195,7 @@ try
         #region Function Get-USRPolicy
         Describe "Get-UserRightsPolicy" {
             Mock -CommandName Get-UserRightsFriendlyName -MockWith { 'Access_Credential_Manager_as_a_trusted_caller' }
-            Mock -CommandName Get-UserRightsAssignment   -MockWith { @{'SeTrustedCredManAccessPrivilege' = "foo" }}
+            Mock -CommandName Get-SecurityPolicy   -MockWith { @{'SeTrustedCredManAccessPrivilege' = "foo" }}
 
             $getUsrResult = Get-UserRightsPolicy -Policy 'Access_Credential_Manager_as_a_trusted_caller'
 
@@ -210,7 +210,7 @@ try
             }
             It 'Should call expected mocks' {
                 Assert-MockCalled -CommandName Get-UserRightsFriendlyName
-                Assert-MockCalled -CommandName Get-UserRightsAssignment
+                Assert-MockCalled -CommandName Get-SecurityPolicy
             }
         }
         #endregion    

--- a/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
+++ b/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
@@ -64,10 +64,10 @@ try
                     Assert-MockCalled -CommandName Start-Process -Exactly 1 -Scope Context -ModuleName SecurityPolicyResourceHelper
                 }
             }
-            Context 'Test Get-UserRightsAssignment' {
+            Context 'Test Get-SecurityPolicy' {
                 $ini = "$PSScriptRoot..\..\..\Misc\TestHelpers\TestIni.txt"
 
-                 $result = Get-UserRightsAssignment $ini
+                 $result = Get-SecurityPolicy $ini
 
                  It 'Should match INI Section' {
                      $result.Keys | Should Be 'section'

--- a/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
+++ b/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
@@ -64,10 +64,10 @@ try
                     Assert-MockCalled -CommandName Start-Process -Exactly 1 -Scope Context -ModuleName SecurityPolicyResourceHelper
                 }
             }
-            Context 'Test Get-SecurityPolicy' {
+            Context 'Test Get-UserRightsAssignment' {
                 $ini = "$PSScriptRoot..\..\..\Misc\TestHelpers\TestIni.txt"
 
-                 $result = Get-SecurityPolicy $ini
+                 $result = Get-UserRightsAssignment $ini
 
                  It 'Should match INI Section' {
                      $result.Keys | Should Be 'section'

--- a/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
+++ b/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
@@ -81,6 +81,30 @@ try
                      $result.section.Key1 | Should be 'Value1'
                  }
             }
+            Context 'Test Get-DomainRole' {
+                Mock -CommandName Get-CimInstance -MockWith {@{'DomainRole'= '4'}}
+
+                $domainRole = Get-DomainRole
+
+                It 'Should return the string "DomainController"' {
+                    $domainRole | Should Be "DomainController"
+                }
+            }
+            Context 'Test Test-IdentityIsNull' {
+                
+                It 'Should return true when null' {
+                    $IdentityIsNull = Test-IdentityIsNull -Identity $null
+                    $domainRole | Should Be $true
+                }
+                It 'Should return true when empty' {
+                    $IdentityIsNull = Test-IdentityIsNull -Identity ''
+                    $domainRole | Should Be $true
+                }
+                It 'Should return false when not null' {
+                    $IdentityIsNull = Test-IdentityIsNull -Identity $null
+                    $domainRole | Should Be $true
+                }
+            }
         } 
     }
 }

--- a/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
+++ b/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
@@ -92,16 +92,16 @@ try
             }
             Context 'Test Test-IdentityIsNull' {
                 
-                It 'Should return true when null' {
+                It 'Should return true when Identity is null' {
                     $IdentityIsNull = Test-IdentityIsNull -Identity $null
                     $IdentityIsNull | Should Be $true
                 }
-                It 'Should return true when empty' {
+                It 'Should return true when Identity is empty' {
                     $IdentityIsNull = Test-IdentityIsNull -Identity ''
                     $IdentityIsNull | Should Be $true
                 }
-                It 'Should return false when not null' {
-                    $IdentityIsNull = Test-IdentityIsNull -Identity $null
+                It 'Should return false when Identity is Guest' {
+                    $IdentityIsNull = Test-IdentityIsNull -Identity 'Guest'
                     $IdentityIsNull | Should Be $false
                 }
             }

--- a/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
+++ b/Tests/Unit/SecurityPolicyResourceHelper.tests.ps1
@@ -94,15 +94,15 @@ try
                 
                 It 'Should return true when null' {
                     $IdentityIsNull = Test-IdentityIsNull -Identity $null
-                    $domainRole | Should Be $true
+                    $IdentityIsNull | Should Be $true
                 }
                 It 'Should return true when empty' {
                     $IdentityIsNull = Test-IdentityIsNull -Identity ''
-                    $domainRole | Should Be $true
+                    $IdentityIsNull | Should Be $true
                 }
                 It 'Should return false when not null' {
                     $IdentityIsNull = Test-IdentityIsNull -Identity $null
-                    $domainRole | Should Be $true
+                    $IdentityIsNull | Should Be $false
                 }
             }
         } 


### PR DESCRIPTION
I have updated to meet most of the new PSSA rules. The rule does not take into account Parametersets. Anything other than mandatory cause the rule to fail. 

The bigger changes come from aligning the names of functions and breaking them down a bit further to make reading and testing easier. This is not the final change, but I wanted to start with a small subset into dev the then bring in the big changes to Set-TargetResoruce for user rights in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/53)
<!-- Reviewable:end -->
