### PR TITLE
Update SecurityPolicyResourceHelper.psm1

### DIFF
--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -169,8 +169,11 @@ function Get-SecurityPolicy
             $privilegeRights = $policyConfiguration.'Privilege Rights'
             foreach ($key in $privilegeRights.keys )
             {
-                $identity = ConvertTo-LocalFriendlyName -Identity $($privilegeRights[$key] -split ",").Trim()
-                $returnValue.Add( $key,$identity )                 
+                
+                If ($privilegeRights[$key]){
+                    $identity = ConvertTo-LocalFriendlyName -Identity $($privilegeRights[$key] -split ",").Trim()
+                    $returnValue.Add( $key, $identity )
+                }               
             }
 
             continue


### PR DESCRIPTION
Validate if $privilegeRights key value is not null, if it is null ConvertTo-LocalFriendlyName throws and error for empty identity input.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/65)
<!-- Reviewable:end -->
