### PR TITLE
Updated SecurityOption to handle multi-line logon messages

### DIFF
--- a/DSCResources/MSFT_SecurityOption/MSFT_SecurityOption.psm1
+++ b/DSCResources/MSFT_SecurityOption/MSFT_SecurityOption.psm1
@@ -42,7 +42,7 @@ function Get-TargetResource
     
         if ( $options.keys -eq 'String' )
         {
-            if ($securityOption -eq 'Interactive_logon_Message_text_for_users_attempting_to_log_on')
+            if ( $securityOption -eq 'Interactive_logon_Message_text_for_users_attempting_to_log_on'  )
             {
                 $resultValue = ($currentValue -split '7,')[-1].Trim()
             }
@@ -531,11 +531,19 @@ function Set-TargetResource
             {
                 if ( [String]::IsNullOrWhiteSpace( $policyData.Option.String ) )
                 {
-                    $newValue = $policy.value                    
+                    $newValue = $policy.Value                                                         
                 }
                 else
-                {
-                    $newValue = "$($policyData.Option.String)" + "$($policy.Value)"
+                {                    
+                    if( $policy.Key -eq 'Interactive_logon_Message_text_for_users_attempting_to_log_on' )
+                    {
+                        $message = Format-LogonMessage -Message $policy.Value
+                        $newValue = "$($policyData.Option.String)" + $message
+                    }
+                    else
+                    {                                           
+                        $newValue = "$($policyData.Option.String)" + "$($policy.Value)"
+                    }
                 }
             }
             elseIf ( $policy.Key -eq 'Network_security_Configure_encryption_types_allowed_for_Kerberos' )
@@ -1008,13 +1016,21 @@ function Test-TargetResource
     {
         if ( $currentSecurityOptions.ContainsKey( $policy ) )
         {
+            if ( $policy -eq 'Interactive_logon_Message_text_for_users_attempting_to_log_on' )
+            {
+                $desiredSecurityOptionValue = Format-LogonMessage -Message $desiredSecurityOptions[$policy]
+            }
+            else
+            {
+                $desiredSecurityOptionValue = $desiredSecurityOptions[$policy]
+            }
             Write-Verbose -Message ( $script:localizedData.TestingPolicy -f $policy )
             Write-Verbose -Message ( $script:localizedData.PoliciesBeingCompared`
-                -f $($currentSecurityOptions[$policy] -join ',' ), $($desiredSecurityOptions[$policy] -join ',' ) )
+                -f $($currentSecurityOptions[$policy] -join ',' ), $($desiredSecurityOptionValue -join ',' ) )
             
-            if ( $desiredSecurityOptions[$policy] -is [array] )
+            if ( $desiredSecurityOptionValue -is [array] )
             {
-                $compareResult = Compare-Array -ReferenceObject $currentSecurityOptions[$policy] -DifferenceObject $desiredSecurityOptions[$policy]
+                $compareResult = Compare-Array -ReferenceObject $currentSecurityOptions[$policy] -DifferenceObject $desiredSecurityOptionValue
 
                 if ( -not $compareResult )
                 {
@@ -1023,7 +1039,7 @@ function Test-TargetResource
             }
             else
             {
-                if ( $currentSecurityOptions[$policy] -ne $desiredSecurityOptions[$policy] )
+                if ( $currentSecurityOptions[$policy] -ne $desiredSecurityOptionValue )
                 {
                     return $false
                 }
@@ -1069,7 +1085,6 @@ function ConvertTo-KerberosEncryptionOption
     $result = $reverseOptions.Keys | Where-Object -FilterScript { $_ -band $newValue } | ForEach-Object -Process {$reverseOptions.Get_Item($_)}
     return $result
 }
-
     
 <#
     .SYNOPSIS
@@ -1129,6 +1144,41 @@ function Compare-Array
     )
 
     return $null -eq (Compare-Object $ReferenceObject $DifferenceObject ).SideIndicator
+}
+
+<#
+    .SYNOPSIS
+        Secedit.exe uses an INI file with security policies and their associated values (key value pair).
+        The value to a policy must be on one line. If the message is a multiple line message a comma is used
+        for the line break and if a comma is intended for grammar it must be surrounded with double quotes.
+
+    .PARAMETER Message
+        The logon message to be formated
+#>
+function Format-LogonMessage
+{
+    [OutputType([string])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Message
+    )
+
+    $formatText = $Message -split '\n'
+
+    if ( $formatText.count -gt 1 )
+    {
+        $lines = $formatText -split '\n' | ForEach-Object -Process { ($PSItem -replace ',','","').Trim() }
+        $resultValue = $lines -join ','
+    }
+    else
+    {
+        $resultValue = $formatText
+    }
+
+    return $resultValue
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/Examples/SecurityOption_LogonMessageMultiLine_Example.ps1
+++ b/Examples/SecurityOption_LogonMessageMultiLine_Example.ps1
@@ -1,0 +1,22 @@
+
+configuration LogonMessage
+{
+    Import-DscResource -ModuleName SecurityPolicyDsc
+    $multiLineMessage = @'
+    Line 1 - Message for line 1.
+    Line 2 - Message for line 2, words, seperated, with, commas.
+    Line 3 - Message for line 3.
+'@
+
+    node localhost
+    {
+        SecurityOption LogonMessage
+        {
+            Name = "Message Test"
+            Interactive_logon_Message_text_for_users_attempting_to_log_on = $multiLineMessage
+        }
+    }
+}
+
+LogonMessage -OutputPath c:\dscMessage
+Start-DscConfiguration -Path c:\dscMessage -Wait -Force -Verbose

--- a/Tests/Unit/MSFT_SecurityOption.tests.ps1
+++ b/Tests/Unit/MSFT_SecurityOption.tests.ps1
@@ -66,7 +66,7 @@ try
                             }
                         }
                     }
-                }
+                }                
             }
 
             Context 'Add-PolicyOption' {
@@ -81,6 +81,23 @@ try
                     [string]$addOptionResult = Add-PolicyOption -SystemAccessPolicies $testPath
 
                     $addOptionResult | Should Match '[System Access]'
+                }
+            }
+
+            Context 'Format-LogonMessage' {
+                $singleLineMessage = 'Line 1 - Message for line 1.,Line 2 - Message for line 2"," words"," seperated"," with"," commas.,Line 3 - Message for line 3.'
+                $multiLineMessage = @'
+                Line 1 - Message for line 1.
+                Line 2 - Message for line 2, words, seperated, with, commas.
+                Line 3 - Message for line 3.
+'@
+                It 'Should return a string' {
+                    $result = Format-LogonMessage -Message $multiLineMessage
+                    $result -is [string] | Should be $true
+                }
+                It 'Should match SingleLineMessage' {
+                    $result = Format-LogonMessage -Message $multiLineMessage
+                    $result -eq $singleLineMessage | Should be $true
                 }
             }
         }


### PR DESCRIPTION
Fixes issue 62.  Allows admin to provide a logon message that is already correctly formatted or the code can handle a multi-line here string which will then be formatted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/67)
<!-- Reviewable:end -->
