### PR TITLE
updated Get-UserRightPolicy to return Identity as array

### DIFF
--- a/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
+++ b/DSCResources/MSFT_UserRightsAssignment/MSFT_UserRightsAssignment.psm1
@@ -494,7 +494,7 @@ function Get-UserRightPolicy
     [PSObject]@{
         Constant     = $userRightConstant
         FriendlyName = $Name
-        Identity     = $userRights[$userRightConstant]
+        Identity     = [array]$userRights[$userRightConstant]
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ to ensure the resource configuration instance is unique.
 ## Versions
 
 ### Unreleased
+* Fixed bug in UserRightAssignment where Get-DscConfiguration would fail if it returns $Identity as single string
 
 ### 2.1.0.0
 * Updated SecurityOption to handle multi-line logon messages


### PR DESCRIPTION
Addresses issue in #69 where Get-DscConfiguration can fail
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/70)
<!-- Reviewable:end -->
