### PR TITLE
Error handling of SID translation and manual translation for Domain Controllers

### DIFF
--- a/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
+++ b/DSCResources/SecurityPolicyResourceHelper/SecurityPolicyResourceHelper.psm1
@@ -330,8 +330,24 @@ function ConvertTo-NTAccount
     {
         $id = ( $id -replace "\*" ).Trim()
 
-        $sidId = [System.Security.Principal.SecurityIdentifier]$id
-        $result += $sidId.Translate([System.Security.Principal.NTAccount]).value
+        try
+        {
+            $sidId = [System.Security.Principal.SecurityIdentifier]$id
+            $result += $sidId.Translate([System.Security.Principal.NTAccount]).value
+        }
+        catch
+        {
+            #Domain Controllers can't translate SID S-1-5-90-0
+            if($id -match "S-1-5-90-0")
+            {
+                $result += "Window Manager\Window Manager Group"
+            }
+            else
+            {
+                write-verbose "SID $id is orphaned, consider removing"
+
+            }
+        }
     }
 
     return $result


### PR DESCRIPTION
Running the DC GPO setting against a DC will prompt you with errors regarding translating security ID.
Troubleshooting turns out that a DC can't resolve S-1-5-90-0 ("Window Manager\Window Manager Group"). This piece of code introduce error handling plus a manual translation for the SID for "Window Manager\Window Manager Group". 