### PR TITLE
Update stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,8 +17,8 @@ pulls:
     Labeling this pull request (PR) as abandoned since it has gone 14 days or more
     since the last update. An abandoned PR can be continued by another contributor.
     The abandoned label will be removed if work on this PR is taken up again.
+
 issues:
-  only: issues
   daysUntilStale: 30
   daysUntilClose: 40
   exemptProjects: true
@@ -38,6 +38,7 @@ issues:
     closed if no further activity occurs within 10 days. If the issue is labelled
     with any of the work labels (e.g bug, enhancement, documentation, or tests)
     then the issue will not auto-close.
+
   closeComment: >
     This issue has been automatically closed because it is has not had activity
     from the community in the last 40 days.


### PR DESCRIPTION
- Removed a keyword that shouldn't have been there (`only:`).

@jcwalker I missed removing the `only:` keyword from the file I redirected you guys to 😞 I fixed the file in xActiveDirectory and SqlServerDsc. This PR resolves it here too.
No need to add it to master if you don't want to, enough that this change is in dev (default branch) for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/95)
<!-- Reviewable:end -->
