### PR TITLE
SecurityOption: fix NTLM Security Option Names

### DIFF
--- a/DSCResources/MSFT_SecurityOption/SecurityOptionData.psd1
+++ b/DSCResources/MSFT_SecurityOption/SecurityOptionData.psd1
@@ -636,7 +636,7 @@
         }
     }
 
-    "Network_Security_Restrict_NTLM_Incoming_NTLM_Traffic" = @{
+    "Network_Security_Restrict_NTLM_Audit_Incoming_NTLM_Traffic" = @{
         Value   = "MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0\AuditReceivingNTLMTraffic"
         Section = 'Registry Values'
         Option  = @{
@@ -646,7 +646,7 @@
         }
     }
 
-    "Network_Security_Restrict_NTLM_NTLM_authentication_in_this_domain" = @{
+    "Network_Security_Restrict_NTLM_Audit_NTLM_authentication_in_this_domain" = @{
         Value   = "MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\AuditNTLMInDomain"
         Section = 'Registry Values'
         Option  = @{
@@ -658,7 +658,7 @@
         }
     }
 
-    "Network_Security_Restrict_NTLM_Outgoing_NTLM_traffic_to_remote_servers" = @{
+    "Network_Security_Restrict_NTLM_Incoming_NTLM_Traffic" = @{
         Value   = "MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0\RestrictReceivingNTLMTraffic"
         Section = 'Registry Values'
         Option  = @{
@@ -668,7 +668,7 @@
         }
     }
 
-    "Network_Security_Restrict_NTLM_Audit_Incoming_NTLM_Traffic" = @{
+    "Network_Security_Restrict_NTLM_NTLM_authentication_in_this_domain" = @{
         Value   = "MACHINE\System\CurrentControlSet\Services\Netlogon\Parameters\RestrictNTLMInDomain"
         Section = 'Registry Values'
         Option  = @{
@@ -680,7 +680,7 @@
         }
     }
 
-    "Network_Security_Restrict_NTLM_Audit_NTLM_authentication_in_this_domain" = @{
+    "Network_Security_Restrict_NTLM_Outgoing_NTLM_traffic_to_remote_servers" = @{
         Value   = "MACHINE\System\CurrentControlSet\Control\Lsa\MSV1_0\RestrictSendingNTLMTraffic"
         Section = 'Registry Values'
         Option  = @{

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ to ensure the resource configuration instance is unique.
 ## Versions
 
 ### Unreleased
-* Bug fix - Network_security_Restrict_NTLM security option names correctly map to underlying registry keys
+* Bug fix - Network_security_Restrict_NTLM security option names now maps to correct keys. This fix could impact your systems.
 
 ### 2.7.0.0
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ to ensure the resource configuration instance is unique.
 ## Versions
 
 ### Unreleased
+* Bug fix - Network_security_Restrict_NTLM security option names correctly map to underlying registry keys
 
 ### 2.7.0.0
 


### PR DESCRIPTION
#### Pull Request (PR) description
The mapping of the Network Security: Restrict NTLM security options to the underlying reg keys was wrong - this has now been fixed.

Not marking this as a breaking change as I expect it would have been found before if anyone tried to use it!


#### This Pull Request (PR) fixes the following issues
None


#### Task list
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/securitypolicydsc/115)
<!-- Reviewable:end -->
